### PR TITLE
Update notify-on-merge.yml

### DIFF
--- a/.github/workflows/notify-on-merge.yml
+++ b/.github/workflows/notify-on-merge.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Send notification to Slack (baghdad-squad)
+      - name: Send basic notification to Slack (baghdad-squad)
         uses: rtCamp/action-slack-notify@v2
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          message: 'A branch has been merged into the development branch! :D'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Mapping SLACK_WEBHOOK_URL to SLACK_WEBHOOK via env

- The problem is that the rtCamp/action-slack-notify@v2 does not use slack_webhook_url as an input name.